### PR TITLE
refactor deprecated createStore to configureStore

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
-import * as serviceWorker from './serviceWorker';
+import {configureStore} from '@redux/toolkit'
 // 
-import {createStore} from 'redux'
 import {Provider} from 'react-redux'
 import rootReducer from './service/reducers/index'
-const store=createStore(rootReducer)
+
+const store = configureStore({
+  reducer: rootReducer
+})
+
 // 
 ReactDOM.render(
   <Provider store={store}>
@@ -16,7 +19,3 @@ ReactDOM.render(
   document.getElementById('root')
 );
 
-// If you want your app to work offline and load faster, you can change
-// unregister() to register() below. Note this comes with some pitfalls.
-// Learn more about service workers: https://bit.ly/CRA-PWA
-serviceWorker.unregister();


### PR DESCRIPTION
Why not use the configureStore from redux-toolkit, if you insist on using createStore, kindly import {legacy_createStore as createStore}